### PR TITLE
Make packages used by Metro config, target "CommonJS"

### DIFF
--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -25,8 +25,6 @@
     "@callstack/polygen-binary-utils": "workspace:^",
     "@callstack/wasm-parser": "workspace:^",
     "execa": "^9.4.1",
-    "find-up": "^7.0.0",
-    "glob": "^11.0.0",
     "indent-string": "^5.0.0",
     "strip-indent": "^4.0.0"
   },

--- a/packages/core-build/package.json
+++ b/packages/core-build/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "The Core libraries of Polygen for generating code",
   "main": "./dist/index.js",
-  "type": "module",
+  "type": "commonjs",
   "files": ["dist"],
   "scripts": {
     "build": "tsc -p tsconfig.json",
@@ -14,7 +14,9 @@
   "license": "MIT",
   "dependencies": {
     "@callstack/polygen-codegen": "workspace:^",
-    "chalk": "^5.3.0"
+    "chalk": "^5.3.0",
+    "find-up": "^5.0.0",
+    "glob": "^11.0.0"
   },
   "devDependencies": {
     "@callstack/polygen-typescript-config": "workspace:^",

--- a/packages/core-build/src/helpers.ts
+++ b/packages/core-build/src/helpers.ts
@@ -1,7 +1,7 @@
 import fsClassic from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'path';
-import { findUp, findUpSync } from 'find-up';
+import findUp from 'find-up';
 import { UnknownProjectError } from './errors.js';
 
 /**
@@ -33,7 +33,7 @@ export async function findProjectRoot(
  * @param from Directory path to start looking from, default to current directory
  */
 export function findProjectRootSync(from: string = process.cwd()): string {
-  const packageJsonPath = findUpSync('package.json', { cwd: from });
+  const packageJsonPath = findUp.sync('package.json', { cwd: from });
 
   if (!packageJsonPath) {
     throw new UnknownProjectError('Could not locate package.json');

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Provides Polygen support for metro bundler",
   "main": "./dist/index.js",
-  "type": "module",
+  "type": "commonjs",
   "files": ["dist"],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1559,7 +1559,7 @@ __metadata:
     ora: "npm:^8.1.0"
     typescript: "npm:^5.7.2"
   bin:
-    polygen: ./bin/polygen
+    polygen: bin/polygen.js
   languageName: unknown
   linkType: soft
 
@@ -1572,8 +1572,6 @@ __metadata:
     "@callstack/wasm-parser": "workspace:^"
     "@types/node": "npm:^22.10.0"
     execa: "npm:^9.4.1"
-    find-up: "npm:^7.0.0"
-    glob: "npm:^11.0.0"
     indent-string: "npm:^5.0.0"
     strip-indent: "npm:^4.0.0"
     typescript: "npm:^5.7.2"
@@ -1587,6 +1585,8 @@ __metadata:
     "@callstack/polygen-codegen": "workspace:^"
     "@callstack/polygen-typescript-config": "workspace:^"
     chalk: "npm:^5.3.0"
+    find-up: "npm:^5.0.0"
+    glob: "npm:^11.0.0"
     typescript: "npm:^5.7.2"
   languageName: unknown
   linkType: soft
@@ -6522,17 +6522,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-up@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "find-up@npm:7.0.0"
-  dependencies:
-    locate-path: "npm:^7.2.0"
-    path-exists: "npm:^5.0.0"
-    unicorn-magic: "npm:^0.1.0"
-  checksum: 10c0/e6ee3e6154560bc0ab3bc3b7d1348b31513f9bdf49a5dd2e952495427d559fa48cdf33953e85a309a323898b43fa1bfbc8b80c880dfc16068384783034030008
-  languageName: node
-  linkType: hard
-
 "flow-enums-runtime@npm:^0.0.6":
   version: 0.0.6
   resolution: "flow-enums-runtime@npm:0.0.6"
@@ -8528,15 +8517,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"locate-path@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "locate-path@npm:7.2.0"
-  dependencies:
-    p-locate: "npm:^6.0.0"
-  checksum: 10c0/139e8a7fe11cfbd7f20db03923cacfa5db9e14fa14887ea121345597472b4a63c1a42a8a5187defeeff6acf98fd568da7382aa39682d38f0af27433953a97751
-  languageName: node
-  linkType: hard
-
 "lodash.camelcase@npm:^4.3.0":
   version: 4.3.0
   resolution: "lodash.camelcase@npm:4.3.0"
@@ -9966,15 +9946,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-limit@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "p-limit@npm:4.0.0"
-  dependencies:
-    yocto-queue: "npm:^1.0.0"
-  checksum: 10c0/a56af34a77f8df2ff61ddfb29431044557fcbcb7642d5a3233143ebba805fc7306ac1d448de724352861cb99de934bc9ab74f0d16fe6a5460bdbdf938de875ad
-  languageName: node
-  linkType: hard
-
 "p-locate@npm:^2.0.0":
   version: 2.0.0
   resolution: "p-locate@npm:2.0.0"
@@ -10008,15 +9979,6 @@ __metadata:
   dependencies:
     p-limit: "npm:^3.0.2"
   checksum: 10c0/2290d627ab7903b8b70d11d384fee714b797f6040d9278932754a6860845c4d3190603a0772a663c8cb5a7b21d1b16acb3a6487ebcafa9773094edc3dfe6009a
-  languageName: node
-  linkType: hard
-
-"p-locate@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "p-locate@npm:6.0.0"
-  dependencies:
-    p-limit: "npm:^4.0.0"
-  checksum: 10c0/d72fa2f41adce59c198270aa4d3c832536c87a1806e0f69dffb7c1a7ca998fb053915ca833d90f166a8c082d3859eabfed95f01698a3214c20df6bb8de046312
   languageName: node
   linkType: hard
 
@@ -10171,13 +10133,6 @@ __metadata:
   version: 4.0.0
   resolution: "path-exists@npm:4.0.0"
   checksum: 10c0/8c0bd3f5238188197dc78dced15207a4716c51cc4e3624c44fc97acf69558f5ebb9a2afff486fe1b4ee148e0c133e96c5e11a9aa5c48a3006e3467da070e5e1b
-  languageName: node
-  linkType: hard
-
-"path-exists@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "path-exists@npm:5.0.0"
-  checksum: 10c0/b170f3060b31604cde93eefdb7392b89d832dfbc1bed717c9718cbe0f230c1669b7e75f87e19901da2250b84d092989a0f9e44d2ef41deb09aa3ad28e691a40a
   languageName: node
   linkType: hard
 
@@ -12889,13 +12844,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unicorn-magic@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "unicorn-magic@npm:0.1.0"
-  checksum: 10c0/e4ed0de05b0a05e735c7d8a2930881e5efcfc3ec897204d5d33e7e6247f4c31eac92e383a15d9a6bccb7319b4271ee4bea946e211bf14951fec6ff2cbbb66a92
-  languageName: node
-  linkType: hard
-
 "unicorn-magic@npm:^0.3.0":
   version: 0.3.0
   resolution: "unicorn-magic@npm:0.3.0"
@@ -13616,13 +13564,6 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
-  languageName: node
-  linkType: hard
-
-"yocto-queue@npm:^1.0.0":
-  version: 1.1.1
-  resolution: "yocto-queue@npm:1.1.1"
-  checksum: 10c0/cb287fe5e6acfa82690acb43c283de34e945c571a78a939774f6eaba7c285bacdf6c90fbc16ce530060863984c906d2b4c6ceb069c94d1e0a06d5f2b458e2a92
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #86 by updating the `"type"` of package.json files of packages used by the example app's Metro config.

- I moved two dependencies from "codegen" into "core-build" (I suspect the code using them got refactored and moved as well).
- Had to downgrade 'find-up' to v5, since v6 and v7 ships ESM only.