### PR TITLE
fix: polyfill setup

### DIFF
--- a/apps/example/metro.config.js
+++ b/apps/example/metro.config.js
@@ -11,9 +11,6 @@ const root = path.resolve(__dirname, '..', '..');
  * @type {import('metro-config').MetroConfig}
  */
 const config = {
-  resolver: {
-    // unstable_enablePackageExports: true,
-  },
   watchFolders: [root],
   transformer: {
     getTransformOptions: async () => ({

--- a/packages/metro-config/src/index.ts
+++ b/packages/metro-config/src/index.ts
@@ -73,7 +73,6 @@ export function withPolygenConfig(
     ...defaultConfig,
     resolver: {
       ...defaultConfig.resolver,
-      unstable_enablePackageExports: true,
       resolveRequest,
       // sourceExts: ['ts', 'tsx', 'js', 'jsx', 'json', 'wasm'],
     },

--- a/packages/polygen/package.json
+++ b/packages/polygen/package.json
@@ -18,16 +18,7 @@
         "default": "./lib/commonjs/index.js"
       }
     },
-    "./polyfill": {
-      "import": {
-        "types": "./lib/typescript/module/polyfill.d.ts",
-        "default": "./lib/module/polyfill.js"
-      },
-      "require": {
-        "types": "./lib/typescript/commonjs/polyfill.d.ts",
-        "default": "./lib/commonjs/polyfill.js"
-      }
-    },
+    "./polyfill": "./polyfill.js",
     "./package.json": "./package.json"
   },
   "files": [
@@ -37,6 +28,7 @@
     "ios",
     "cpp",
     "*.podspec",
+    "polyfill.js",
     "!ios/build",
     "!android/build",
     "!android/gradle",

--- a/packages/polygen/polyfill.js
+++ b/packages/polygen/polyfill.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var polygen = require('@callstack/polygen');
+
+global.WebAssembly = Object.freeze(polygen.WebAssembly);

--- a/packages/polygen/react-native.config.js
+++ b/packages/polygen/react-native.config.js
@@ -2,9 +2,6 @@
  * @type {import('@react-native-community/cli-types').UserDependencyConfig}
  */
 module.exports = {
-  resolver: {
-    unstable_enablePackageExports: true,
-  },
   dependency: {
     platforms: {
       android: {

--- a/packages/polygen/src/polyfill.ts
+++ b/packages/polygen/src/polyfill.ts
@@ -1,6 +1,0 @@
-// @ts-ignore
-import { WebAssembly } from '@callstack/polygen';
-// @ts-ignore
-global.WebAssembly = Object.freeze(WebAssembly) as any;
-// @ts-ignore
-globalThis.WebAssembly = Object.freeze(WebAssembly);


### PR DESCRIPTION
I've added a static entry for polyfill that doesn't need to get transpiled in form a CJS module that will be used in runtime by RN. This also removes a need to set `packageExports` by default through a metro config