### PR TITLE
Fix init in package without dependencies

### DIFF
--- a/.changeset/clean-radios-cover.md
+++ b/.changeset/clean-radios-cover.md
@@ -1,0 +1,5 @@
+---
+"@callstack/polygen-cli": patch
+---
+
+Fix running 'init' command in a package with no dependencies

--- a/packages/polygen-cli/src/commands/init.ts
+++ b/packages/polygen-cli/src/commands/init.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import {
@@ -40,9 +41,19 @@ async function maybeAddDeps(
   const { verbose } = options;
   const pkgJsonPath = path.join(projectRoot, 'package.json');
   const pkgJsonText = await fs.readFile(pkgJsonPath, 'utf8');
-  const pkgJson = JSON.parse(pkgJsonText);
 
-  const { dependencies } = pkgJson;
+  const pkgJson = JSON.parse(pkgJsonText) as unknown;
+  assert(
+    typeof pkgJson === 'object' && pkgJson !== null,
+    'Expected package.json to be an object'
+  );
+
+  const { dependencies = {} } = pkgJson as Record<string, unknown>;
+  assert(
+    typeof dependencies === 'object' && dependencies !== null,
+    'Expected dependencies to be an object'
+  );
+
   if ('@callstack/polygen' in dependencies) {
     consola.debug(
       "@callstack/polygen is already in project's dependencies, skipping..."


### PR DESCRIPTION
I was initializing into a package with no pre-existing dependencies and got an error:

```
ℹ Creating polygen.config.mjs... 5:29:35 AM
file:///Users/kraen.hansen/.npm/_npx/4ac4a1edf82d52ad/node_modules/@callstack/polygen-cli/dist/commands/init.js:26
if ('@callstack/polygen' in dependencies) {
^

TypeError: Cannot use 'in' operator to search for '@callstack/polygen' in undefined
at maybeAddDeps (file:///Users/kraen.hansen/.npm/_npx/4ac4a1edf82d52ad/node_modules/@callstack/polygen-cli/dist/commands/init.js:26:30)
at async Command.<anonymous> (file:///Users/kraen.hansen/.npm/_npx/4ac4a1edf82d52ad/node_modules/@callstack/polygen-cli/dist/commands/init.js:73:27)
at async Command.parseAsync (/Users/kraen.hansen/.npm/_npx/4ac4a1edf82d52ad/node_modules/commander/lib/command.js:1092:5)
at async run (file:///Users/kraen.hansen/.npm/_npx/4ac4a1edf82d52ad/node_modules/@callstack/polygen-cli/dist/index.js:36:9)

Node.js v22.11.0
```