### PR TITLE
Add any .rb scripts to the package

### DIFF
--- a/.changeset/gorgeous-swans-agree.md
+++ b/.changeset/gorgeous-swans-agree.md
@@ -1,0 +1,5 @@
+---
+"@callstack/polygen": patch
+---
+
+Include missing polygen.rb in polygen package.

--- a/packages/polygen/package.json
+++ b/packages/polygen/package.json
@@ -30,6 +30,7 @@
     "ios",
     "cpp",
     "*.podspec",
+    "*.rb",
     "!ios/build",
     "!android/build",
     "!android/gradle",


### PR DESCRIPTION
Adds the missing `polygen.rb` to the package archive.

Verified by inspecting the output of:

```
yarn pack --dry-run
```