### PR TITLE
Update exports to reflect

### DIFF
--- a/packages/polygen/package.json
+++ b/packages/polygen/package.json
@@ -8,18 +8,9 @@
   "react-native": "",
   "bin": "cli.mjs",
   "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "require": "./dist/index.js"
-    },
-    "./polyfill": {
-      "types": "./dist/polyfill.d.ts",
-      "require": "./dist/polyfill.js"
-    },
-    "./config": {
-      "types": "./dist/config.d.ts",
-      "require": "./dist/config.js"
-    },
+    ".": "./dist/index.js",
+    "./polyfill": "./dist/polyfill.js",
+    "./config": "./dist/config.js",
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/polygen/package.json
+++ b/packages/polygen/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/index.d.ts",
   "react-native": "",
   "bin": "cli.mjs",
+  "type": "commonjs",
   "exports": {
     ".": "./dist/index.js",
     "./polyfill": "./dist/polyfill.js",


### PR DESCRIPTION
This fixes #134 by simplifying the exports to point directly to the JavaScript files.

TypeScript will automatically guess and use the `.d.ts` files.

Using an explicit `"types"` export condition is only needed if the type files are in a location which cannot be inferred.